### PR TITLE
Updated get_thumbnail_video dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   transparent_image: ^2.0.1
-  get_thumbnail_video: ^0.6.1
+  get_thumbnail_video: ^0.7.3
   video_player: ^2.9.1
   cross_file: ^0.3.4+2
 


### PR DESCRIPTION
Updated get_thumbnail_video dependency from 0.6.1 to 0.7.3
Now projects that uses video_editor_2 compile on Android